### PR TITLE
Potential fix for code scanning alert no. 11: Flask app is run in debug mode

### DIFF
--- a/web/app.py
+++ b/web/app.py
@@ -443,6 +443,7 @@ if __name__ == '__main__':
     # Parse command line arguments
     parser = argparse.ArgumentParser(description='GEAD Web Application')
     parser.add_argument('--port', type=int, default=5000, help='Port to run the server on')
+    parser.add_argument('--debug', action='store_true', help='Run the server in debug mode')
     args = parser.parse_args()
     
     # Try the specified port, or find an available one
@@ -464,4 +465,4 @@ if __name__ == '__main__':
                 sys.exit(1)
     
     print(f"Starting server on port {port}")
-    app.run(host='0.0.0.0', port=port, debug=True)
+    app.run(host='0.0.0.0', port=port, debug=args.debug)


### PR DESCRIPTION
Potential fix for [https://github.com/dongtsi/GEAD/security/code-scanning/11](https://github.com/dongtsi/GEAD/security/code-scanning/11)

To fix the problem, we need to ensure that the Flask application does not run in debug mode in a production environment. The best way to achieve this is by making the debug mode configurable through command-line arguments or environment variables. This way, we can easily switch between development and production modes without changing the code.

We will modify the `app.run` call to use a command-line argument to determine whether to run in debug mode. This involves adding a new argument to the argument parser and using its value in the `app.run` call.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
